### PR TITLE
Note workaround for loadlocale.c assertion failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ brunch $device
 ```
 where ***$device*** is either **amami** or **oneplus3**.
 
+Note: If the build fails with an assertion in loadlocale.c, it is likely [this problem](https://groups.google.com/forum/#!topic/android-building/0kzPnw3akxg). Work around it with `export LC_ALL=C` or `unset LANG` before running `brunch $device`.
+
 ## How to initially set up your build tree:
 ```Shell session
 repo init -u https://github.com/LineageOS/android.git -b lineage-15.1 --groups=all,-notdefault,-darwin,-x86,-mips


### PR DESCRIPTION
Note how to work around the following build failure on recent linux hosts with certain locale environment settings:

    Lex: applypatch <= bootable/recovery/edify/lexer.ll
    FAILED: /mnt/buildboxext/project/android/makebox-oreo/out/target/product/amami/obj/STATIC_LIBRARIES/libedify_intermediates/lexer.cpp
    /bin/bash -c "prebuilts/misc/linux-x86/flex/flex-2.5.39 -o/mnt/buildboxext/project/android/makebox-oreo/out/target/product/amami/obj/STATIC_LIBRARIES/libedify_intermediates/lexer.cpp bootable/recovery/edify/lexer.ll"
    flex-2.5.39: loadlocale.c:130: _nl_intern_locale_data: Assertion `cnt < (sizeof (_nl_value_type_LC_TIME) / sizeof (_nl_value_type_LC_TIME[0]))' failed. 